### PR TITLE
License attribution

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright 2010 François de Metz <francois@2metz.fr>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "type": "git",
     "url": "git+https://github.com/strophe/strophejs-plugin-roster.git"
   },
-  "author": "",
+  "author": "Strophe plugin developers",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/strophe/strophejs-plugin-roster/issues"

--- a/src/strophe.roster.js
+++ b/src/strophe.roster.js
@@ -1,6 +1,3 @@
-/*
-  Copyright 2010, François de Metz <francois@2metz.fr>
-*/
 import { $iq, $pres, Strophe } from 'strophe.js';
 
 /**


### PR DESCRIPTION
Move license attribution to LICENSE file to follow [GitHub recommendation](https://help.github.com/articles/licensing-a-repository/).