### PR TITLE
Do not try to add to roster if not yet fetched

### DIFF
--- a/src/strophe.roster.js
+++ b/src/strophe.roster.js
@@ -471,7 +471,9 @@ Strophe.addConnectionPlugin('roster',
                 groups       : groups,
                 resources    : {}
             };
-            this.items.push(item);
+            if (this.items) {
+                this.items.push(item);
+            }
         }
         else
         {


### PR DESCRIPTION
This is a rare occurrence that throws an error. Steps to reproduce:

1. Add the plugin but _do not_ get the roster.
2. Add a new contact to the user's roster, e.g. using a different client.

The plugin will receive a message about the new contact. But it will throw an error because `this.items` is not yet created.